### PR TITLE
chore: tidy up scripts and remove unused wrappers

### DIFF
--- a/assets/js/cookies.js
+++ b/assets/js/cookies.js
@@ -1,25 +1,25 @@
 function setCookie(name, value, days) {
-    var expires = "";
+    let expires = "";
     if (days) {
-        var date = new Date();
-        date.setTime(date.getTime() + (days*24*60*60*1000));
+        const date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
         expires = "; expires=" + date.toUTCString();
     }
     document.cookie = name + "=" + (value || "") + expires + "; path=/";
 }
 
 function getCookie(name) {
-    var nameEQ = name + "=";
-    var ca = document.cookie.split(';');
-    for(var i=0;i < ca.length;i++) {
-        var c = ca[i];
-        while (c.charAt(0)==' ') c = c.substring(1,c.length);
-        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+    const nameEQ = name + "=";
+    const ca = document.cookie.split(";");
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === " ") c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length);
     }
     return null;
 }
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", () => {
     const cbElem = document.getElementById("cookie-banner");
 
     function cbHide() {
@@ -36,12 +36,12 @@ document.addEventListener("DOMContentLoaded", function () {
         }, 100);
     }
 
-    document.getElementById("cookie-accept-required").addEventListener("click", function () {
+    document.getElementById("cookie-accept-required").addEventListener("click", () => {
         setCookie("cookie_consent", "required", 365);
         cbHide();
     });
 
-    document.getElementById("cookie-accept-all").addEventListener("click", function () {
+    document.getElementById("cookie-accept-all").addEventListener("click", () => {
         setCookie("cookie_consent", "all", 365);
         cbHide();
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,2 @@
-(function () {
-    pagination(false);
-})();
+pagination(false);
+

--- a/assets/js/matomo.js
+++ b/assets/js/matomo.js
@@ -1,22 +1,22 @@
-// Matomo
 if (matomoEnabled) {
-    function loadMatomo() {
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    window.loadMatomo = function () {
+        const _paq = (window._paq = window._paq || []);
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
-        (function() {
-            var u=matomoURL;
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', matomoSiteID]);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    }
+
+        const u = matomoURL;
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', matomoSiteID]);
+        const d = document;
+        const g = d.createElement('script');
+        const s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = u + 'matomo.js';
+        s.parentNode.insertBefore(g, s);
+    };
 
     // Load only if cookie already accepted
     if (document.cookie.includes("cookie_consent=all")) {
         loadMatomo();
     }
 }
-// End Matomo Code

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ function handleError(done) {
         }
         return done(err);
     };
-};
+}
 
 function hbs(done) {
     pump([


### PR DESCRIPTION
## Summary
- simplify pagination script and tidy Matomo loader
- modernize cookie helper utilities
- clean up gulp error handler
- revert built main.min.js so the PR only touches source files

## Testing
- `npx gulp build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f468f957c832f8a0696ee9f7bc192